### PR TITLE
fix: override filter field and apply sort on computed fields to make them sortable and filterable.

### DIFF
--- a/src/ExportFields/Computed.php
+++ b/src/ExportFields/Computed.php
@@ -2,6 +2,8 @@
 
 namespace Revo\Sidecar\ExportFields;
 
+use Illuminate\Database\Eloquent\Builder;
+use Revo\Sidecar\Filters\Filters;
 use Revo\Sidecar\Filters\GroupBy;
 
 class Computed extends ExportField
@@ -36,6 +38,14 @@ class Computed extends ExportField
     public function displayFormat(string $format) : self {
         $this->displayFormat = $format;
         return $this;
+    }
+
+    public function getFilterField() : string {
+        return $this->title; // Computed fields has to use their name to filter or sort
+    }
+
+    public function applySort(Filters $filters, Builder $query){
+        $filters->sort->sort($query, $filters->sort->field); // Computed fields are not database fields, so we don't need to add the database full
     }
 
     public function getTitle(): string


### PR DESCRIPTION
The problem was that the computed fields were using the related field to sort or filter when it has to be the given name, for example this Computed field 
`Computed::make('id', 'average')->onGroupingBy('sum(milliliters)/count(id)')->onlyWhenGrouping()->sortable()` produces this on a query `(sum(milliliters)/count(id)) as average` so if we want to sort we need to use average instad of id.

The other problem was it was adding the table name before the field, so it was looking for a non existing fields on the DB

<img width="393" alt="image" src="https://user-images.githubusercontent.com/11394100/198568202-bfed1548-26f8-498b-a8c3-a85a6ddb8bc8.png">

<img width="395" alt="image" src="https://user-images.githubusercontent.com/11394100/198568235-f20d7863-92d6-40de-ba3e-29b09c2c337b.png">
