### PR TITLE
fix: escape text when exporting to csv.

### DIFF
--- a/resources/views/widgets/csvTable.blade.php
+++ b/resources/views/widgets/csvTable.blade.php
@@ -1,8 +1,8 @@
 @if($rows)
 {{ $fields->map->getTitle()->implode(";") }}
 @foreach($rows as $row)
-    {{ $fields->map(function($field) use($row) {
+    {!! $fields->map(function($field) use($row) {
         return $field->toCsv($row);
-    })->implode(";") }}
+    })->implode(";") !!}
 @endforeach
 @endif


### PR DESCRIPTION
The current separator for csv is the `;` character that is also a symbol that appears when escaping som symbols like `< >`

Previous behaviour:
`Can&#039;t get exchange rate`
`&lt;system&gt;`

Current behaviour with this PR
`Can't get exchange rate`
`<system>`

