### PR TITLE
Filters visibility refactor (groupBy Dates)

### DIFF
--- a/resources/views/filters.blade.php
+++ b/resources/views/filters.blade.php
@@ -4,14 +4,15 @@
         <input type="hidden" name="sort_order" value="{{request('sort_order')}}">
 
         <div class="flex flex-col gap-2 md:space-y-0 md:flex-row md:items-center">
-            <div class="flex flex-row justify-left items-center gap-2">
-                @foreach($report->availableFilters() as $field)
-                    @includeWhen($field instanceof Revo\Sidecar\ExportFields\Date, 'sidecar::filters.date')
-                @endforeach
-                @if ($report->isComparable())
-                    @include('sidecar::filters.dateCompare')
-                @endif
-            </div>
+            @if ($report->availableFilters()->contains(fn ($filter) => $filter instanceof Revo\Sidecar\ExportFields\Date) || $report->isComparable())
+                <div class="flex flex-row justify-left items-center gap-2">
+                    @foreach($report->availableFilters() as $field)
+                        @includeWhen($field instanceof Revo\Sidecar\ExportFields\Date, 'sidecar::filters.date')
+                    @endforeach
+                    
+                    @includeWhen($report->isComparable(), 'sidecar::filters.dateCompare')
+                </div>
+            @endif
             <div class="flex flex-col md:flex-row w-full md:w-auto justify-left items-center gap-2 md:grow">
                 <div class="grow w-full">
                 @include('sidecar::filters.groupBy')

--- a/resources/views/filters/groupBy.blade.php
+++ b/resources/views/filters/groupBy.blade.php
@@ -1,23 +1,24 @@
 @if ($report->availableGroupings()->count() > 0)
     <div class="sidecar-group-by w-full flex flex-col md:flex-row items-center gap-2">
-        
-        <x-ui::forms.searchable-select class="h-14" id="sidecar-groupby-date" name="groupBy[]" placeholder="{{__(config('sidecar.translationsPrefix').'groupBy') }}..." class="w-full min-w-44 md:w-auto" icon="calendar-plus">
-            @foreach($report->availableGroupings() as $filter)
-                @if(count($filter->groupings()) > 1)
-                    <option value="">--</option>
-                    @foreach($filter->groupings() as $grouping)
-                        <option value="{{$filter->getFilterField()}}:{{$grouping}}"
-                                @if ($report->filters->groupBy->isGroupingBy($filter->getFilterField(), $grouping)) selected @endif>
-                            @if ($grouping == "default")
-                                {{ str_replace(" (default)", "", "{$filter->getTitle()}") }}
-                            @else
-                                {{ str_replace(" (default)", "", $filter->getTitle() . " (" . trans_choice(config('sidecar.translationsPrefix').$grouping, 1) . ")") }}
-                            @endif
-                        </option>
-                    @endforeach
-                @endif
-            @endforeach
-        </x-ui::forms.searchable-select>
+        @if ($report->availableGroupings()->contains(fn ($grouping) => $grouping instanceof Revo\Sidecar\ExportFields\Date))
+            <x-ui::forms.searchable-select class="h-14" id="sidecar-groupby-date" name="groupBy[]" placeholder="{{__(config('sidecar.translationsPrefix').'groupBy') }}..." class="w-full min-w-44 md:w-auto" icon="calendar-plus">
+                @foreach($report->availableGroupings() as $filter)
+                    @if(count($filter->groupings()) > 1)
+                        <option value="">--</option>
+                        @foreach($filter->groupings() as $grouping)
+                            <option value="{{$filter->getFilterField()}}:{{$grouping}}"
+                                    @if ($report->filters->groupBy->isGroupingBy($filter->getFilterField(), $grouping)) selected @endif>
+                                @if ($grouping == "default")
+                                    {{ str_replace(" (default)", "", "{$filter->getTitle()}") }}
+                                @else
+                                    {{ str_replace(" (default)", "", $filter->getTitle() . " (" . trans_choice(config('sidecar.translationsPrefix').$grouping, 1) . ")") }}
+                                @endif
+                            </option>
+                        @endforeach
+                    @endif
+                @endforeach
+            </x-ui::forms.searchable-select>
+        @endif
 
         <x-ui::forms.multiple-select id="sidecar-groupby" name="groupBy[]" placeholder="{{__(config('sidecar.translationsPrefix').'groupBy') }}..." class="w-full" icon="layer-group">
             @foreach($report->availableGroupings() as $filter)


### PR DESCRIPTION
Linear tasca original: https://linear.app/revo/issue/REV-15844/llistat-de-stocks-incomprensible

Aquest refactor és per evitar mostrar aquest filtre si no té sentit:
<img width="666" alt="image" src="https://github.com/user-attachments/assets/5f83d89c-ba17-457e-aaf0-6c495767a075">

I per netejar l'espai generat pel gap i la divisió buida:
<img width="1067" alt="image" src="https://github.com/user-attachments/assets/a64c34ae-b765-4285-b84a-ede6bfee3a35">
